### PR TITLE
`seneca@0.5.18` compatibility

### DIFF
--- a/test/client.js
+++ b/test/client.js
@@ -4,8 +4,10 @@ var nid = require('nid');
 var seneca = require('seneca')();
 
 seneca
-  .use('..', { kafka: { namespace: 'seneca', group: 'seneca', requestTopic: 'request', responseTopic: 'response'},
-               microbial: { zkroot: 'localhost:2181', namespace: 'seneca', start: 'all'}})
+  .use(require('../'), {
+    kafka: { namespace: 'seneca', group: 'seneca', requestTopic: 'request', responseTopic: 'response'},
+    microbial: { zkroot: 'localhost:2181', namespace: 'seneca', start: 'all'}
+  })
   .client({type:'queue'})
   .ready(function(){
     var s= this;

--- a/test/server.js
+++ b/test/server.js
@@ -3,8 +3,10 @@
 var seneca = require('seneca')();
 
 seneca
-  .use('..', { kafka: { namespace: 'seneca', group: 'seneca', requestTopic: 'request', responseTopic: 'response'},
-               microbial: { zkroot: 'localhost:2181', namespace: 'seneca', start: 'all'}})
+  .use(require('../'), {
+    kafka: { namespace: 'seneca', group: 'seneca', requestTopic: 'request', responseTopic: 'response'},
+    microbial: { zkroot: 'localhost:2181', namespace: 'seneca', start: 'all'}
+  })
   .use('foo')
   .listen( {type:'queue'} );
 


### PR DESCRIPTION
This makes `seneca-kafka-transport` work with `seneca@0.5.18`.
